### PR TITLE
ci: update setup-go version

### DIFF
--- a/.github/actions/install-conforma-plugin/action.yml
+++ b/.github/actions/install-conforma-plugin/action.yml
@@ -11,7 +11,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up Go
-      uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
+      uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
       with:
         go-version: '1.24'
         cache: false

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -29,7 +29,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Go
-        uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
+        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
         with:
           go-version: '1.24'
           cache: false

--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -26,7 +26,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Go
-        uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
+        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
         with:
           go-version: '1.24'
           cache: false


### PR DESCRIPTION
Replaces the dependabot PR https://github.com/complytime/baseline-demo/pull/14 by also including `.github/actions/install-conforma-plugin/action.yml`