### PR TITLE
chore: configure dependabot for GitHub Actions dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,10 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      - "/.github/actions/install-conforma-plugin"
+      - "/.github/actions/run-checks"
     schedule:
       interval: "daily"
     commit-message:


### PR DESCRIPTION
Add dependabot configuration to automatically update GitHub Actions dependencies.

Related: https://github.com/complytime/complyctl/pull/294