### PR TITLE
chore: CPLYTM-1322 update all complytime refs to complytime-labs for migrated repos

### DIFF
--- a/.github/actions/install-conforma-plugin/action.yml
+++ b/.github/actions/install-conforma-plugin/action.yml
@@ -20,7 +20,7 @@ runs:
     - name: Build
       env:
         VERSION: ${{ inputs.version }}
-      run: go install "github.com/complytime/compliance-to-policy-plugins/opa-plugin@$VERSION"
+      run: go install "github.com/complytime-labs/compliance-to-policy-plugins/opa-plugin@$VERSION"
       shell: bash
 
     - name: Add to path

--- a/cmd/cli/component.go
+++ b/cmd/cli/component.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/complytime/gemara2oscal/component"
+	"github.com/complytime-labs/gemara2oscal/component"
 	oscalTypes "github.com/defenseunicorns/go-oscal/src/types/oscal-1-1-3"
 	"github.com/goccy/go-yaml"
 	"github.com/ossf/gemara/layer2"

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"os"
 
-	"github.com/complytime/baseline-demo/cmd/cli"
+	"github.com/complytime-labs/baseline-demo/cmd/cli"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,9 @@
-module github.com/complytime/baseline-demo
+module github.com/complytime-labs/baseline-demo
 
 go 1.24.4
 
 require (
-	github.com/complytime/gemara2oscal v0.0.0-20251027194523-4ead3ea25a6c
+	github.com/complytime-labs/gemara2oscal v0.0.0-20251027194523-4ead3ea25a6c
 	github.com/defenseunicorns/go-oscal v0.7.0
 	github.com/goccy/go-yaml v1.19.2
 	github.com/spf13/cobra v1.10.2
@@ -24,6 +24,6 @@ require (
 )
 
 replace (
-	github.com/complytime/gemara2oscal => github.com/complytime/gemara2oscal v0.0.0-20251107222047-9887878c2711
+	github.com/complytime-labs/gemara2oscal => github.com/complytime-labs/gemara2oscal v0.0.0-20251107222047-9887878c2711
 	github.com/ossf/gemara => github.com/jpower432/sci v0.0.0-20251107221736-76054b25e204
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/complytime/gemara2oscal v0.0.0-20251107222047-9887878c2711 h1:44dMR+e5mW4hoT6aCy7U/j4Uz6UuyBqgMPvQuKARf/o=
-github.com/complytime/gemara2oscal v0.0.0-20251107222047-9887878c2711/go.mod h1:p/oFPgghWxoe4bIRZSL/Ova2IunXU/1XWUzu7gmamSE=
+github.com/complytime-labs/gemara2oscal v0.0.0-20251107222047-9887878c2711 h1:44dMR+e5mW4hoT6aCy7U/j4Uz6UuyBqgMPvQuKARf/o=
+github.com/complytime-labs/gemara2oscal v0.0.0-20251107222047-9887878c2711/go.mod h1:p/oFPgghWxoe4bIRZSL/Ova2IunXU/1XWUzu7gmamSE=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
Replaces github.com/complytime/REPO with github.com/complytime-labs/REPO for all repos that migrated. References to repos staying in complytime (e.g. complybeacon, complyctl, complyscribe) are preserved.

Part of complytime → complytime-labs migration.